### PR TITLE
Add RepositoryDst

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: android
 android:
   components:
     - tools
-    - build-tools-26.0.1
+    - build-tools-26.0.2
     - android-26
     - extra-android-m2repository
     - extra-android-support

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -155,6 +155,8 @@ dependencies {
 
     // Testing
     testCompile "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
+    testCompile 'com.willowtreeapps.assertk:assertk:0.9'
+
     androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
     androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
 
@@ -168,4 +170,6 @@ dependencies {
         exclude module: 'hamcrest-core'
     }
     testCompile 'org.hamcrest:hamcrest-library:1.3'
+
+    testCompile 'org.jsoup:jsoup:1.10.3'
 }

--- a/app/src/main/java/solutions/alterego/android/unisannio/Faculties.kt
+++ b/app/src/main/java/solutions/alterego/android/unisannio/Faculties.kt
@@ -4,18 +4,16 @@ import solutions.alterego.android.unisannio.ateneo.AteneoAvvisiParser
 import solutions.alterego.android.unisannio.giurisprudenza.GiurisprudenzaParser
 import solutions.alterego.android.unisannio.ingegneria.IngegneriaAvvisiDipartimentoParser
 import solutions.alterego.android.unisannio.ingegneria.IngegneriaAvvisiStudentiParser
+import solutions.alterego.android.unisannio.interfaces.Parser
 import solutions.alterego.android.unisannio.map.UniPoint
 import solutions.alterego.android.unisannio.map.UnisannioGeoData
 import solutions.alterego.android.unisannio.models.Article
-import solutions.alterego.android.unisannio.scienze.ScienzeDetailParser
-import solutions.alterego.android.unisannio.scienze.ScienzeParser
 import solutions.alterego.android.unisannio.sea.SeaParser
-import solutions.alterego.android.unisannio.interfaces.Parser
 
-sealed class Faculty(
+class Faculty(
     val nameResource: Int /* Ingegneria */,
-    val mainUrl: String /* https://www.ding.unisannio.it/ */,
-    val mapPoints: List<UniPoint>,
+    val website: String /* https://www.ding.unisannio.it/ */,
+    val mapMarkers: List<UniPoint>,
     val sections: List<Section>,
     val detailParser: Parser<String>? = null
 )
@@ -26,7 +24,7 @@ data class Section(
     val parser: Parser<Article> /* IngegneriaAvvisiStudentiParser */
 )
 
-class AteneoFaculty : Faculty(
+val AteneoFaculty = Faculty(
     R.string.ateneo,
     URLS.ATENEO,
     UnisannioGeoData.ATENEO(),
@@ -44,7 +42,7 @@ class AteneoFaculty : Faculty(
     )
 )
 
-class IngegneriaFaculty : Faculty(
+val IngegneriaFaculty = Faculty(
     R.string.ingegneria,
     URLS.INGEGNERIA,
     UnisannioGeoData.INGEGNERIA(),
@@ -62,21 +60,7 @@ class IngegneriaFaculty : Faculty(
     )
 )
 
-class ScienzeFaculty : Faculty(
-    R.string.scienze,
-    URLS.SCIENZE,
-    UnisannioGeoData.SCIENZE(),
-    listOf(
-        Section(
-            R.string.title_activity_scienze,
-            URLS.SCIENZE_NEWS,
-            ScienzeParser()
-        )
-    ),
-    ScienzeDetailParser()
-)
-
-class GiurisprudenzaFaculty : Faculty(
+val GiurisprudenzaFaculty = Faculty(
     R.string.giurisprudenza,
     URLS.GIURISPRUDENZA,
     UnisannioGeoData.GIURISPRUDENZA(),
@@ -94,7 +78,7 @@ class GiurisprudenzaFaculty : Faculty(
     )
 )
 
-class SeaFaculty : Faculty(
+val SeaFaculty = Faculty(
     R.string.sea,
     URLS.SEA,
     UnisannioGeoData.SEA(),

--- a/app/src/main/java/solutions/alterego/android/unisannio/dst/FacultyDst.kt
+++ b/app/src/main/java/solutions/alterego/android/unisannio/dst/FacultyDst.kt
@@ -1,0 +1,23 @@
+package solutions.alterego.android.unisannio.dst
+
+import solutions.alterego.android.unisannio.Faculty
+import solutions.alterego.android.unisannio.R
+import solutions.alterego.android.unisannio.R.string
+import solutions.alterego.android.unisannio.Section
+import solutions.alterego.android.unisannio.map.UnisannioGeoData
+import solutions.alterego.android.unisannio.scienze.ScienzeDetailParser
+import solutions.alterego.android.unisannio.scienze.ScienzeParser
+
+val FacultyDst = Faculty(
+    nameResource = R.string.scienze,
+    website = "http://www.dstunisannio.it/",
+    mapMarkers = UnisannioGeoData.SCIENZE(),
+    sections = listOf(
+        Section(
+            string.title_activity_scienze,
+            "http://www.dstunisannio.it/index.php/didattica?format=feed&type=rss",
+            ScienzeParser()
+        )
+    ),
+    detailParser = ScienzeDetailParser()
+)

--- a/app/src/main/java/solutions/alterego/android/unisannio/dst/RepositoryDst.kt
+++ b/app/src/main/java/solutions/alterego/android/unisannio/dst/RepositoryDst.kt
@@ -1,0 +1,67 @@
+package solutions.alterego.android.unisannio.dst
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import rx.Observable
+import rx.Single
+import solutions.alterego.android.unisannio.Faculty
+import solutions.alterego.android.unisannio.models.Article
+import javax.inject.Inject
+
+interface Parser {
+    fun parse(document: Document): Single<List<Article>>
+}
+
+interface Retriever {
+    fun retrieve(url: String): Single<Document>
+}
+
+interface Repository {
+    fun loadArticles(): Observable<List<Article>>
+}
+
+class RepositoryDst @Inject constructor(
+    private val parser: Parser,
+    private val retriever: Retriever,
+    private val faculty: Faculty
+) : Repository {
+
+    override fun loadArticles(): Observable<List<Article>> = fetchFromNetwork()
+
+    private fun fetchFromNetwork(): Observable<List<Article>> {
+        return retriever.retrieve(faculty.sections[0].url)
+            .flatMap { parser.parse(it) }
+            .toObservable()
+    }
+}
+
+class ParserDst : Parser {
+    override fun parse(document: Document): Single<List<Article>> {
+        return Single.fromCallable {
+            document.select("item")
+                .asSequence()
+                .map {
+                    Article(
+                        id = it.select("guid").first().text(),
+                        title = it.select("title").first().text(),
+                        author = it.select("author").first().text(),
+                        url = it.select("link").first().text(),
+                        body = it.select("description").first().text(),
+                        date = it.select("pubDate").first().text()
+                    )
+                }
+                .toList()
+        }
+    }
+}
+
+class RetrieverDst : Retriever {
+    override fun retrieve(url: String): Single<Document> {
+        return Single.fromCallable {
+            Jsoup.connect(url)
+                .timeout(10 * 1000)
+                .parser(org.jsoup.parser.Parser.xmlParser())
+                .get()
+        }
+    }
+}

--- a/app/src/test/java/solutions/alterego/android/MockitoRxTest.kt
+++ b/app/src/test/java/solutions/alterego/android/MockitoRxTest.kt
@@ -1,0 +1,29 @@
+package solutions.alterego.android
+
+import org.junit.After
+import org.junit.Before
+import org.mockito.MockitoAnnotations
+import rx.Scheduler
+import rx.android.plugins.RxAndroidPlugins
+import rx.android.plugins.RxAndroidSchedulersHook
+import rx.plugins.RxJavaHooks
+import rx.schedulers.Schedulers
+
+open class MockitoRxTest {
+    @Before open fun setup() {
+        MockitoAnnotations.initMocks(this)
+
+        RxJavaHooks.setOnIOScheduler { Schedulers.immediate() }
+        RxAndroidPlugins.getInstance().registerSchedulersHook(object : RxAndroidSchedulersHook() {
+            override fun getMainThreadScheduler(): Scheduler? {
+                return Schedulers.immediate()
+            }
+        })
+    }
+
+    @After
+    fun tearDown() {
+        RxJavaHooks.reset()
+        RxAndroidPlugins.getInstance().reset()
+    }
+}

--- a/app/src/test/java/solutions/alterego/android/unisannio/dst/ParserDstTest.kt
+++ b/app/src/test/java/solutions/alterego/android/unisannio/dst/ParserDstTest.kt
@@ -1,0 +1,34 @@
+package solutions.alterego.android.unisannio.dst
+
+import assertk.assertions.isGreaterThan
+import org.jsoup.nodes.Document
+import org.junit.Test
+import rx.observers.TestSubscriber
+import solutions.alterego.android.MockitoRxTest
+import solutions.alterego.android.unisannio.models.Article
+
+@Suppress("IllegalIdentifier")
+class ParserDstTest : MockitoRxTest() {
+
+    @Test
+    fun `parse DST article from DST document`() {
+        val retriever = RetrieverDst()
+        val retrieverSubscriber = TestSubscriber<Document>()
+        retriever.retrieve(FacultyDst.sections[0].url).subscribe(retrieverSubscriber)
+        val document = retrieverSubscriber.onNextEvents.first()
+
+        val parser = ParserDst()
+
+        val parserSubscriber = TestSubscriber<List<Article>>()
+
+        parser.parse(document).subscribe(parserSubscriber)
+
+        parserSubscriber.assertCompleted()
+        parserSubscriber.assertNoErrors()
+
+        val articles = parserSubscriber.onNextEvents.first()
+
+        assertk.assert(articles.size).isGreaterThan(0)
+    }
+
+}

--- a/app/src/test/java/solutions/alterego/android/unisannio/dst/RepositoryDst.kt
+++ b/app/src/test/java/solutions/alterego/android/unisannio/dst/RepositoryDst.kt
@@ -1,0 +1,29 @@
+@file:Suppress("IllegalIdentifier")
+
+package solutions.alterego.android.unisannio.dst
+
+import assertk.assert
+import assertk.assertions.isEqualTo
+import org.jsoup.nodes.Document
+import org.junit.Test
+import rx.observers.TestSubscriber
+import solutions.alterego.android.MockitoRxTest
+
+class RetrieverDstTest : MockitoRxTest() {
+
+    @Test
+    fun `retrieve DST RSS`() {
+        val retriever = RetrieverDst()
+
+        val subscriber = TestSubscriber<Document>()
+        retriever.retrieve(FacultyDst.sections[0].url).subscribe(subscriber)
+
+        subscriber.assertNoErrors()
+        subscriber.assertCompleted()
+
+        val document = subscriber.onNextEvents.first()
+        val title = document.select("title")[0].text()
+
+        assert(title).isEqualTo("DST | Didattica :: notizie")
+    }
+}


### PR DESCRIPTION
Relates to https://github.com/alter-ego/unisannio-reboot/issues/99

Add first Repository PoC for faculties, using DST as testbench.

A Repository comes with

* a `Parser`
* a `Retriever`
* a `Faculty`

The public API is just one method:

```
fun loadArticles(): Observable<List<Article>>
```

In this first implementation, the `Observeble` will emit only one `List`
and complete.

In the next implementation we will have also a local storage layer that
will instantly provide the last downloaded list and, once the new list
will be downloaded, will emit a second list.